### PR TITLE
replace apt-key since it is deprecated in debian 12

### DIFF
--- a/chirpstack/install.sh
+++ b/chirpstack/install.sh
@@ -42,8 +42,8 @@ rm -f /tmp/init_sql.sql
 #3. install lora packages
 #3.1 install https requirements
 #apt -f -y install apt-transport-https dirmngr
-apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1CE2AFD36DBCCA00
-echo "deb https://artifacts.chirpstack.io/packages/3.x/deb stable main" | sudo tee /etc/apt/sources.list.d/chirpstack.list
+gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/chirpstack.gpg --keyserver keyserver.ubuntu.com --recv-keys 1CE2AFD36DBCCA00
+echo "deb [signed-by=/usr/share/keyrings/chirpstack.gpg] https://artifacts.chirpstack.io/packages/3.x/deb stable main" | tee /etc/apt/sources.list.d/chirpstack.list
 apt update
 apt install chirpstack-network-server
 apt install chirpstack-gateway-bridge


### PR DESCRIPTION
apt-key is deprecated. therefore the install of chirpstack will fail.
Instead a gpg file is created and referenced in the sources.list file